### PR TITLE
replaced disontinued cdn for socket.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Reveal.initialize({
 		secret: Reveal.getQueryHash().s || null
 	},
 	dependencies: [
-        	{ src: 'https://cdn.socket.io/socket.io-2.0.3.js', async: true },
+        	{ src: 'https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.3/socket.io.js', async: true },
         	{ src: Reveal.getQueryHash().s ?
 		  'plugin/multiplex/master.js' :
 		  'plugin/multiplex/client.js', async: true }


### PR DESCRIPTION
the other server caused an error

`was blocked due to MIME type mismatch (X-Content-Type-Options: nosniff)`

which, as I read on [stackoverflow](https://stackoverflow.com/questions/40728554/resource-blocked-due-to-mime-type-mismatch-x-content-type-options-nosniff) happens if a path is wrong